### PR TITLE
Add roundtrip retrier for http client

### DIFF
--- a/retry/README.md
+++ b/retry/README.md
@@ -14,7 +14,7 @@ import (
 
 func main() {
 
-    r := retry.NewRetrier()
+    r := retry.NewRetrier(0.125, 0.25, 2, new(retry.Exp))
   
     err := r.Retry(context.Background(), func() (bool, error) {
    		// do things
@@ -40,7 +40,7 @@ import (
 )
 
 func main() {
-        retryRoundTripper := retry.NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, []int{http.StatusBadRequest})
+        retryRoundTripper := retry.NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, []int{http.StatusBadRequest}, new(retry.Exp))
 	httpClient := new(http.Client)
 	httpClient.Transport = retryRoundTripper
 

--- a/retry/README.md
+++ b/retry/README.md
@@ -1,4 +1,4 @@
-# Usage
+# Usage of Retrier
 
 Retry supervised do funcs which automatically handle failures when they occur by performing retries.
 
@@ -13,8 +13,9 @@ import (
 )
 
 func main() {
-	r := retry.NewRetrier()
-    
+
+    r := retry.NewRetrier()
+  
     err := r.Retry(context.Background(), func() (bool, error) {
    		// do things
    		return true, nil
@@ -23,5 +24,34 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
+}
+```
+
+# Usage of Roundtripper Retrier
+
+## Example 
+```go 
+package main 
+
+import (
+	"github.com/donutloop/toolkit/retry"
+	"log"
+	"context"
+)
+
+func main() {
+        retryRoundTripper := retry.NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, []int{http.StatusBadRequest})
+	httpClient := new(http.Client)
+	httpClient.Transport = retryRoundTripper
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil )
+	if err != nil {
+		//...
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		//...
+	}
 }
 ```

--- a/retry/doc_test.go
+++ b/retry/doc_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ExampleRetrier() {
-	r := retry.NewRetrier(0.125, 0.25, 2)
+	r := retry.NewRetrier(0.125, 0.25, 2, new(retry.Exp))
 	err := r.Retry(context.Background(), func() (bool, error) {
 		fmt.Println("fire request")
 		return true, nil

--- a/retry/doc_test.go
+++ b/retry/doc_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ExampleRetrier() {
-	r := retry.NewRetrier()
+	r := retry.NewRetrier(0.125, 0.25, 2)
 	err := r.Retry(context.Background(), func() (bool, error) {
 		fmt.Println("fire request")
 		return true, nil

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -11,52 +11,46 @@ import (
 	"time"
 )
 
-const standardTriesCount uint = 10
-
 type ExhaustedError struct{}
 
 func (r *ExhaustedError) Error() string {
 	return "function never succeeded in Retry"
 }
 
+type Retrier interface {
+	Retry(ctx context.Context, do RetryableDo) error
+}
+
 type RetryableDo func() (bool, error)
 
-func NewRetrier() *Retrier {
-	return &Retrier{
-		InitialInterval: 1,
-		MaxInterval:     3,
-		Tries:           standardTriesCount,
+func NewRetrier(InitialIntervalInSeconds, maxIntervalInSeconds float64, tries uint) Retrier {
+	return &retrier{
+		initialIntervalInSeconds: InitialIntervalInSeconds,
+		maxIntervalInSeconds:     maxIntervalInSeconds,
+		tries:           tries,
 	}
 }
 
 // Retry supervised do funcs which automatically handle failures when they occur by performing retries.
-type Retrier struct {
-	InitialInterval float64
-	MaxInterval     float64
-	Tries           uint
+type retrier struct {
+	initialIntervalInSeconds float64
+	maxIntervalInSeconds     float64
+	tries           uint
 }
 
-func (r *Retrier) Retry(ctx context.Context, do RetryableDo) error {
+func (r *retrier) Retry(ctx context.Context, do RetryableDo) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	if r.InitialInterval <= 0 {
-		r.InitialInterval = 1
-	}
-
-	if r.Tries == 0 {
-		r.Tries = standardTriesCount
-	}
-
-	if r.InitialInterval > r.MaxInterval {
-		return fmt.Errorf("initial interval is greater than max (initial: %f, max: %f)", r.InitialInterval, r.MaxInterval)
+	if r.initialIntervalInSeconds > r.maxIntervalInSeconds {
+		return fmt.Errorf("initial interval is greater than max (initial: %f, max: %f)", r.initialIntervalInSeconds, r.maxIntervalInSeconds)
 	}
 
 	var err error
 	var done bool
-	interval := r.InitialInterval
-	for i := uint(0); !done && i < r.Tries; i++ {
+	interval := r.initialIntervalInSeconds
+	for i := uint(0); !done && i < r.tries; i++ {
 		done, err = do()
 
 		if ctx.Err() != nil {
@@ -69,7 +63,7 @@ func (r *Retrier) Retry(ctx context.Context, do RetryableDo) error {
 
 		if !done {
 			time.Sleep(time.Duration(interval) * time.Second)
-			interval = math.Min(interval*2, r.MaxInterval)
+			interval = math.Min(interval*2, r.maxIntervalInSeconds)
 		}
 	}
 

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRetrierRetryContextDeadlineFail(t *testing.T) {
-	r := retry.NewRetrier(0.125, 0.25, 2)
+	r := retry.NewRetrier(0.125, 0.25, 2, new(retry.Exp))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -31,7 +31,7 @@ func TestRetrierRetryContextDeadlineFail(t *testing.T) {
 }
 
 func TestRetrierRetry(t *testing.T) {
-	r := retry.NewRetrier(0.125, 0.25, 2)
+	r := retry.NewRetrier(0.125, 0.25, 2, new(retry.Exp))
 	err := r.Retry(context.Background(), func() (bool, error) {
 		return true, nil
 	})
@@ -42,7 +42,7 @@ func TestRetrierRetry(t *testing.T) {
 }
 
 func TestRetrierRetryTriggerError(t *testing.T) {
-	r := retry.NewRetrier(0.125, 0.25, 2)
+	r := retry.NewRetrier(0.125, 0.25, 2, new(retry.Exp))
 	err := r.Retry(context.Background(), func() (bool, error) {
 		return false, errors.New("stub error")
 	})
@@ -58,7 +58,7 @@ func TestRetrierRetryTriggerError(t *testing.T) {
 }
 
 func TestRetrierRetryFail(t *testing.T) {
-	r := retry.NewRetrier(0.125, 0.25, 2)
+	r := retry.NewRetrier(0.125, 0.25, 2, new(retry.Exp))
 
 	err := r.Retry(context.Background(), func() (bool, error) {
 		return false, nil

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRetrierRetryContextDeadlineFail(t *testing.T) {
-	r := retry.NewRetrier()
+	r := retry.NewRetrier(0.125, 0.25, 2)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -31,7 +31,7 @@ func TestRetrierRetryContextDeadlineFail(t *testing.T) {
 }
 
 func TestRetrierRetry(t *testing.T) {
-	r := retry.NewRetrier()
+	r := retry.NewRetrier(0.125, 0.25, 2)
 	err := r.Retry(context.Background(), func() (bool, error) {
 		return true, nil
 	})
@@ -42,7 +42,7 @@ func TestRetrierRetry(t *testing.T) {
 }
 
 func TestRetrierRetryTriggerError(t *testing.T) {
-	r := retry.NewRetrier()
+	r := retry.NewRetrier(0.125, 0.25, 2)
 	err := r.Retry(context.Background(), func() (bool, error) {
 		return false, errors.New("stub error")
 	})
@@ -58,10 +58,7 @@ func TestRetrierRetryTriggerError(t *testing.T) {
 }
 
 func TestRetrierRetryFail(t *testing.T) {
-	r := retry.NewRetrier()
-	r.InitialInterval = 0.125
-	r.Tries = 2
-	r.MaxInterval = 0.25
+	r := retry.NewRetrier(0.125, 0.25, 2)
 
 	err := r.Retry(context.Background(), func() (bool, error) {
 		return false, nil

--- a/retry/roundtripper.go
+++ b/retry/roundtripper.go
@@ -12,8 +12,8 @@ type RoundTripper struct {
 }
 
 // NewRoundTripper is constructing a new retry RoundTripper with given default values
-func NewRoundTripper(next http.RoundTripper, maxInterval, initialInterval float64, tries uint, blacklistStatusCodes []int) *RoundTripper {
-	retrier := NewRetrier(initialInterval, maxInterval, tries)
+func NewRoundTripper(next http.RoundTripper, maxInterval, initialInterval float64, tries uint, blacklistStatusCodes []int, strategy Strategy) *RoundTripper {
+	retrier := NewRetrier(initialInterval, maxInterval, tries, strategy)
 	return &RoundTripper{
 		retrier:retrier,
 		next: next,

--- a/retry/roundtripper.go
+++ b/retry/roundtripper.go
@@ -1,0 +1,63 @@
+package retry
+
+import (
+	"context"
+	"net/http"
+)
+
+type RoundTripper struct {
+	retrier Retrier
+	next http.RoundTripper
+	blacklistStatusCodes []int
+}
+
+// NewRoundTripper is constructing a new retry RoundTripper with given default values
+func NewRoundTripper(next http.RoundTripper, maxInterval, initialInterval float64, tries uint, blacklistStatusCodes []int) *RoundTripper {
+	retrier := NewRetrier(initialInterval, maxInterval, tries)
+	return &RoundTripper{
+		retrier:retrier,
+		next: next,
+		blacklistStatusCodes: blacklistStatusCodes,
+	}
+}
+
+// RoundTrip is retrying a outgoing request in case of bad status code and not blacklisted status codes
+// if rt.next.RoundTrip(req) is return an error then it will abort the process retrying a request
+func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var resp *http.Response
+	err := rt.retrier.Retry(context.Background(), func() (b bool, e error) {
+		var err error
+		resp, err = rt.next.RoundTrip(req)
+		if err != nil {
+			return false, err
+		}
+
+		if resp.StatusCode > 308 {
+			if rt.isStatusCode(resp.StatusCode) {
+				return true, nil
+			}
+			return false, nil
+		}
+
+		return true , nil
+	})
+
+	if _, ok := err.(*ExhaustedError); ok  {
+		return resp, nil
+	}
+
+	return resp, err
+}
+
+// isStatusCode iterates over list of black listed status code that it could abort the process of retrying a request
+func (rt *RoundTripper) isStatusCode(statusCode int) bool {
+	if rt.blacklistStatusCodes == nil {
+		return false
+	}
+	for _, sc := range rt.blacklistStatusCodes {
+		if statusCode == sc {
+			return true
+		}
+	}
+	return false
+}

--- a/retry/roundtripper_test.go
+++ b/retry/roundtripper_test.go
@@ -16,7 +16,7 @@ func TestRoundTripper_RoundTripInternalServer(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 	}))
 
-	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, nil)
+	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, nil, new(Exp))
 	httpClient := new(http.Client)
 	httpClient.Transport = retryRoundTripper
 
@@ -48,7 +48,7 @@ func TestRoundTripper_RoundTripInternalServerBlacklisted(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
-	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, []int{http.StatusInternalServerError})
+	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, []int{http.StatusInternalServerError}, new(Exp))
 	httpClient := new(http.Client)
 	httpClient.Transport = retryRoundTripper
 
@@ -80,7 +80,7 @@ func TestRoundTripper_RoundTripStatusOk(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, nil)
+	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, nil, new(Exp))
 	httpClient := new(http.Client)
 	httpClient.Transport = retryRoundTripper
 

--- a/retry/roundtripper_test.go
+++ b/retry/roundtripper_test.go
@@ -1,0 +1,104 @@
+package retry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRoundTripper_RoundTripInternalServer(t *testing.T) {
+
+	var counter int32
+	testserver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			atomic.AddInt32(&counter, 1)
+			t.Log("hit endpoint")
+			w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, nil)
+	httpClient := new(http.Client)
+	httpClient.Transport = retryRoundTripper
+
+	req, err := http.NewRequest(http.MethodGet, testserver.URL, nil )
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("response is bad, got=%v", resp.StatusCode)
+	}
+
+	if counter != 3 {
+		t.Errorf("counter is bad, got=%v, want=%v", counter, 3)
+	}
+}
+
+func TestRoundTripper_RoundTripInternalServerBlacklisted(t *testing.T) {
+
+	var counter int32
+	testserver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&counter, 1)
+		t.Log("hit endpoint")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, []int{http.StatusInternalServerError})
+	httpClient := new(http.Client)
+	httpClient.Transport = retryRoundTripper
+
+	req, err := http.NewRequest(http.MethodGet, testserver.URL, nil )
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("response is bad, got=%v", resp.StatusCode)
+	}
+
+	if counter != 1 {
+		t.Errorf("counter is bad, got=%v, want=%v", counter, 1)
+	}
+}
+
+func TestRoundTripper_RoundTripStatusOk(t *testing.T) {
+
+	var counter int32
+	testserver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&counter, 1)
+		t.Log("hit endpoint")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	retryRoundTripper := NewRoundTripper(http.DefaultTransport, .50 , .15 , 3, nil)
+	httpClient := new(http.Client)
+	httpClient.Transport = retryRoundTripper
+
+	req, err := http.NewRequest(http.MethodGet, testserver.URL, nil )
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("response is bad, got=%v", resp.StatusCode)
+	}
+
+	if counter != 1 {
+		t.Errorf("counter is bad, got=%v, want=%v", counter, 1)
+	}
+}


### PR DESCRIPTION
# Feature

Roundtrip retrier: it is retrying a request in case of a server has responded with a bad status code and this status code isn't blacklisted by the RoundTripper.

## Advantages 

* Retry of request happens on transport layer instead of mixing it up with business logic

## Disadvantages

* Globally defined retrier

## Refactoring

* Defined a interface for retrier 
* Removed default parameters for retrier
* Adapt retrier constructor for injecting parameters

